### PR TITLE
Added optional Dio parameter

### DIFF
--- a/lib/src/cached_tile_provider.dart
+++ b/lib/src/cached_tile_provider.dart
@@ -14,13 +14,15 @@ class CachedTileProvider extends TileProvider {
   /// Create a new [CachedTileProvider]
   CachedTileProvider({
     required CacheStore store,
+    Dio? dio,
     BaseOptions? dioOptions,
     List<Interceptor>? interceptors,
     Duration? maxStale,
     CacheKeyBuilder? keyBuilder,
     List<int>? hitCacheOnErrorExcept = defaultHitCacheOnErrorExcept,
-  }) : dio = Dio(dioOptions) {
-    dio.interceptors.addAll([
+  }) : dio = dio ?? Dio(dioOptions) {
+    this.dio.options = dioOptions ?? BaseOptions();
+    this.dio.interceptors.addAll([
       if (interceptors != null) ...interceptors,
       DioCacheInterceptor(
         options: CacheOptions(


### PR DESCRIPTION
Previously, there was no way to mock the Dio client, meaning you couldn't test the map while using the CachedTileProvider.  This PR adds the optional dio parameter for use with the http_mock_adapter package.  I currently set it up so that the passed Dio client's options are set to the options in the parameters, but asserting that one or the other must be null would work also.